### PR TITLE
Fix No module named jupyter_client.kernelspecapp error

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -26,7 +26,7 @@ export PATH=\"$PY3PATH:\$PATH\"" >> $BASH_RC
 $CONDA3 install --yes seaborn
 
 # python 2 environment
-$CONDA3 create --yes -n python2 python=2 pip ipython pyzmq
+$CONDA3 create --yes -n python2 python=2 pip ipython=3.2.1 pyzmq
 
 # ipython setup
 $PY3PATH/ipython profile create default --ipython-dir $HOME/.ipython


### PR DESCRIPTION
When Python 2 conda environment is created, it pulls the most recent `IPython` (currently 4.0.0)
The project seems to be in flux right now between IPython/Jupyter and referring to the old way of registering the Python 2 kernel generates an error and prevents the build. Complete error message below.

The line that generates the error is this:
https://github.com/rothnic/anaconda-notebook/blob/c45256491fee3f0995e022b1dc96f4f467b14972/Dockerfile#L40-41

Explicitly installing IPython 3 at least makes the image able to build-- a quick fix.

A better solution is likely to upgrade the whole image to install `jupyter` and its related commands for registering the kernel  instead of `ipython`.

Here's the complete error message:

``` bash
Step 12 : RUN $PY2PATH/python $PY2PATH/ipython kernelspec install-self
 ---> Running in c4f7d80d376f
Traceback (most recent call last):
  File "/home/condauser/anaconda3/envs/python2/bin/ipython", line 6, in <module>
    sys.exit(start_ipython())
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/IPython/__init__.py", line 118, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/traitlets/config/application.py", line 591, in launch_instance
    app.initialize(argv)
  File "<string>", line 2, in initialize
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/IPython/terminal/ipapp.py", line 305, in initialize
    super(TerminalIPythonApp, self).initialize(argv)
  File "<string>", line 2, in initialize
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/IPython/core/application.py", line 386, in initialize
    self.parse_command_line(argv)
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/IPython/terminal/ipapp.py", line 300, in parse_command_line
    return super(TerminalIPythonApp, self).parse_command_line(argv)
  File "<string>", line 2, in parse_command_line
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/traitlets/config/application.py", line 487, in parse_command_line
    return self.initialize_subcommand(subc, subargv)
  File "<string>", line 2, in initialize_subcommand
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/traitlets/config/application.py", line 75, in catch_config_error
    return method(app, *args, **kwargs)
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/traitlets/config/application.py", line 418, in initialize_subcommand
    subapp = import_item(subapp)
  File "/home/condauser/anaconda3/envs/python2/lib/python2.7/site-packages/ipython_genutils/importstring.py", line 31, in import_item
    module = __import__(package, fromlist=[obj])
ImportError: No module named jupyter_client.kernelspecapp
The command '/bin/sh -c $PY2PATH/python $PY2PATH/ipython kernelspec install-self' returned a non-zero code: 1
```
